### PR TITLE
feat(backend): sockets store their room code

### DIFF
--- a/common/src/socket-types/SocketData.ts
+++ b/common/src/socket-types/SocketData.ts
@@ -1,7 +1,11 @@
+import { RoomCode } from "./ClientToServerEvents.js";
+
 /**
  * Additional information that is attached to each client
  */
 interface SocketData {
   username: string;
+  roomCode: RoomCode | undefined;
 }
+
 export default SocketData;


### PR DESCRIPTION
I found out that you can store additional data and attach it to the `socket` that represents a single browser connection. The first thing that I'm going to do is associate each browser connection with a `roomCode: RoomCode | undefined`. 

New Invariants:
- If the socket's RoomCode is undefined, that means that the browser connection is not currently collaborating on an Ensemble. 
- If the socket's RoomCode is defined, that means that the browser connection **is currently in an Ensemble session**.