### PR TITLE
chore(infra): enforce file extensions for wider os support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,12 @@
       }
     },
     "overrides": [
+      {
+        "files": ["frontend/**/*"],
+        "rules": {
+          "node/file-extension-in-import": "off"
+        }
+      }
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -27,9 +33,11 @@
     "plugins": [
         "react",
         "react-hooks",
+        "eslint-plugin-node",
         "@typescript-eslint"
     ],
     "rules": {
+        "node/file-extension-in-import": ["error", "always", { "tryExtensions": [".js", ".json", ".node"]}],
         "@typescript-eslint/no-shadow": ["error", { "allow": ["_"] }],
         "consistent-return": "error",
         "camelcase": "error",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,7 +12,7 @@ import {
 import registerRoomEvents from "./routes/rooms.js";
 import path from "path";
 import { fileURLToPath } from "url";
-import registerEnsembleEvents from "./routes/ensemble";
+import registerEnsembleEvents from "./routes/ensemble.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/backend/src/routes/ensemble.ts
+++ b/backend/src/routes/ensemble.ts
@@ -1,6 +1,6 @@
 import { ClientToServerEvents, Instrument } from "common/dist/index.js";
-import { IoType, SocketType } from "./types";
-import { rooms } from "./rooms";
+import { IoType, SocketType } from "./types.js";
+import { rooms } from "./rooms.js";
 
 const registerEnsembleEvents = (io: IoType, socket: SocketType) => {
   const fetchEnsemble: ClientToServerEvents["ensemble:fetch"] = (callback) => {

--- a/backend/src/routes/rooms.ts
+++ b/backend/src/routes/rooms.ts
@@ -1,5 +1,5 @@
 import { Ensemble, RoomCode } from "common/dist/index.js";
-import { IoType, SocketType } from "./types";
+import { IoType, SocketType } from "./types.js";
 
 export const rooms: Record<RoomCode, Ensemble> = {};
 

--- a/common/src/ensembles/BarLine.ts
+++ b/common/src/ensembles/BarLine.ts
@@ -79,7 +79,7 @@ export class BarLine {
   /**
    * Returns the note at the given position. Returns undefined if the
    * position is out of range.
-   * 
+   *
    * @param row The row of the note
    * @param col The column of the note
    * @returns The note at the given position
@@ -92,7 +92,7 @@ export class BarLine {
   /**
    * Sets the note at the given position. Does nothing if the position
    * is out of range.
-   * 
+   *
    * @param row The row of the note
    * @param col The column of the note
    * @param note The note to set
@@ -105,7 +105,7 @@ export class BarLine {
   /**
    * Gets the type of the note at the given position. Returns undefined
    * if the position is out of range.
-   * 
+   *
    * @param row The row of the note
    * @param col The column of the note
    * @returns The type of the note at the given position

--- a/frontend/src/views/ensemble/Metronome.tsx
+++ b/frontend/src/views/ensemble/Metronome.tsx
@@ -24,16 +24,15 @@ const Metronome: FC = () => {
 
   useEffect(() => {
     if (!playing) return setBeatNumber(-1);
-    
 
     const intervalId = setInterval(
       () => setBeatNumber((old) => (old + 1) % 32),
       tempoMS,
     );
-    
+
     return () => {
       clearInterval(intervalId);
-    }
+    };
   }, [playing, setBeatNumber]);
 
   return (

--- a/frontend/src/views/ensemble/SingleNote.tsx
+++ b/frontend/src/views/ensemble/SingleNote.tsx
@@ -67,12 +67,12 @@ const SingleNote: FC<SingleNoteProps> = ({ beatNumber, pitch }) => {
         instrumentSampler = tubaSampler;
         break;
     }
-    
+
     // Trigger a music note if we are not a NoteType.REST
     if (currentNoteType === NoteType.ATTACK) {
       // instrumentSampler.triggerAttack(PITCH_VALUES[pitch]);
       Tone.Transport.scheduleOnce((time) => {
-        instrumentSampler.triggerAttackRelease(PITCH_VALUES[pitch], '4n', time);
+        instrumentSampler.triggerAttackRelease(PITCH_VALUES[pitch], "4n", time);
       }, Tone.now());
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@typescript-eslint/parser": "^6.9.0",
         "eslint": "^8.52.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "pre-commit": "^1.2.2",
@@ -3076,6 +3077,25 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
     "node_modules/eslint-plugin-eslint-comments": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
@@ -3102,6 +3122,35 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "dependencies": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.16.0"
+      }
+    },
+    "node_modules/eslint-plugin-node/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -3207,6 +3256,30 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -5406,6 +5479,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/require-directory": {
@@ -8790,6 +8875,16 @@
         }
       }
     },
+    "eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      }
+    },
     "eslint-plugin-eslint-comments": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
@@ -8804,6 +8899,28 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -8882,6 +8999,23 @@
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
@@ -10386,6 +10520,12 @@
         "define-properties": "^1.2.0",
         "set-function-name": "^2.0.0"
       }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/parser": "^6.9.0",
     "eslint": "^8.52.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "pre-commit": "^1.2.2",


### PR DESCRIPTION
I added a new ESLint rule that throws an error if the import does not have the file extension. This is because Josh's computer cannot seem to run the stack locally without these file extensions in the `/backend` or `/common` packages. However, Josh's computer seems to run just fine when the `/frontend` package omits file extensions. 

To be minimally invasive, I've limited the scope of this ESLint rule to only the files in the `/backend` and `/common` directories. I did this by using the ESLint override. I turned off the rule for the `/frontend` directory. 

Documentation for this ESLint rule can be found [here](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/file-extension-in-import.md). 

I chose not to enable all of the recommended rules to keep this PR minimally invasive. We might want to do this at some point, but I don't think it's valuable at this stage of development. 