### PR TITLE
fix(infra): fix style check

### DIFF
--- a/.github/workflows/style-and-lint.yaml
+++ b/.github/workflows/style-and-lint.yaml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Run style check
       run: |
-        npm run style
+        npm run style-check
         if [ $? -ne 0 ]; then
           echo "Code style check failed. Please fix the issues before merging."
           exit 1


### PR DESCRIPTION
I mistakenly ran this command which fixes style:
```
npm run style
```

I replaced it with this command which checks style and throws an error if it doesn't pass style rule:
```
npm run style-check
```