### PR TITLE
refactor(frontend): make a dict of samplers

### DIFF
--- a/frontend/src/views/ensemble/barline/Samplers.tsx
+++ b/frontend/src/views/ensemble/barline/Samplers.tsx
@@ -5,6 +5,7 @@ import GuitarB2 from "frontend/src/assets/samples/GuitarB2.wav";
 import BassF2 from "frontend/src/assets/samples/BassF2.wav";
 import AltoSaxDb4 from "frontend/src/assets/samples/AltoSaxDb4.wav";
 import TubaD3 from "frontend/src/assets/samples/TubaD3.wav";
+import { Instrument } from "common/dist";
 
 export const fluteSampler = new Tone.Sampler({
   urls: {
@@ -47,3 +48,19 @@ export const tubaSampler = new Tone.Sampler({
   },
   release: 1,
 }).toDestination();
+
+/**
+ * The Tone.js samplers for each instrument
+ *
+ * @note The Record type enforces that all Instrument enums are covered.
+ * If we add a new instrument, this will throw a type error until we add
+ * the new instrument to the Record.
+ */
+export const samplers: Record<Instrument, Tone.Sampler> = {
+  [Instrument.FLUTE]: fluteSampler,
+  [Instrument.MARIMBA]: marimbaSampler,
+  [Instrument.GUITAR]: guitarSampler,
+  [Instrument.BASS]: bassSampler,
+  [Instrument.ALTO_SAX]: altoSaxSampler,
+  [Instrument.TUBA]: tubaSampler,
+};

--- a/frontend/src/views/ensemble/barline/SingleNote.tsx
+++ b/frontend/src/views/ensemble/barline/SingleNote.tsx
@@ -1,18 +1,11 @@
-import { Instrument, NoteType, UserID } from "common/dist";
+import { NoteType, UserID } from "common/dist";
 import { FC, useEffect, useState } from "react";
 import { Box } from "@mui/material";
 import { useRecoilState, useRecoilValue, useRecoilValueLoadable } from "recoil";
 import { beatNumberAtom } from "../../../recoil/beat";
 import { paletteAtom } from "../../../recoil/palette";
 import { paletteDict } from "../../../ui-components/Palette";
-import {
-  altoSaxSampler,
-  bassSampler,
-  fluteSampler,
-  guitarSampler,
-  marimbaSampler,
-  tubaSampler,
-} from "./Samplers";
+import { samplers } from "./Samplers";
 import { ensembleAtom } from "../../../recoil/ensemble";
 import { socketAtom, userIDSelector } from "../../../recoil/socket";
 import * as Tone from "tone";
@@ -56,7 +49,7 @@ const SingleNote: FC<SingleNoteProps> = ({ beatNumber, pitch, author }) => {
     if (!playNow) return;
 
     // Assign correct instrument sounds to what player selected
-    const sampler = getSampler(currentInstrument);
+    const sampler = samplers[currentInstrument];
 
     // Trigger a music note if we are not a NoteType.REST
     if (currentNoteType === NoteType.ATTACK) {
@@ -75,26 +68,6 @@ const SingleNote: FC<SingleNoteProps> = ({ beatNumber, pitch, author }) => {
     userID,
     author,
   ]);
-
-  // Change instrument sound based on currently selected
-  const getSampler = (instrument: Instrument) => {
-    switch (instrument) {
-      case Instrument.FLUTE:
-        return fluteSampler;
-      case Instrument.ALTO_SAX:
-        return altoSaxSampler;
-      case Instrument.MARIMBA:
-        return marimbaSampler;
-      case Instrument.GUITAR:
-        return guitarSampler;
-      case Instrument.BASS:
-        return bassSampler;
-      case Instrument.TUBA:
-        return tubaSampler;
-      default:
-        return fluteSampler;
-    }
-  };
 
   // Store if we are currently hovering over it
   const [onHover, setOnHover] = useState(false);


### PR DESCRIPTION
Recall that `Instrument` is an enum.

I replaced the switch statement inside of `getInstrument` with a dictionary. This is a special Typescript dictionary type:  `Record<Instrument, Tone.Sampler>`. The pattern is `Record<KeyType, ValueType>`.

The special behavior is that if you set KeyType to an enum, it forces you to define a value for every enum. For example, suppose we have this enum:
```typescript
enum Animal {
  DOG,
  CAT,
  FISH
}

// This will throw an error because we are missing Animal.FISH
const name1: Record<Animal, string> = {
  [Animal.DOG]: "Happy",
  [Animal.CAT]: "Millie"
}

// This will not throw an error because we capture all Animal values as keys
const name2: Record<Animal, string> = {
  [Animal.DOG]: "Happy",
  [Animal.CAT]: "Millie",
  [Animal.FISH]: "Dinner"
}```
