### PR TITLE
feat(backend): buffer time before deleting a room

### DIFF
--- a/backend/src/routes/rooms.ts
+++ b/backend/src/routes/rooms.ts
@@ -33,7 +33,15 @@ const registerRoomEvents = (io: IoType, socket: SocketType) => {
     // Let everyone in the room know the list of users changed
     io.to(currentRoomCode).emit("room:user-list", ensemble.getMembers());
     io.to(currentRoomCode).emit("ensemble:update", ensemble.toObject());
-    if (ensemble.getMembers().length === 0) delete rooms[currentRoomCode];
+    // If the room is empty, wait some time before deleting it. This is to
+    // prevent the room from being deleted if the last user refreshed.
+    if (ensemble.getMembers().length === 0) {
+      setTimeout(() => {
+        // If it is still empty, delete the room
+        if (ensemble.getMembers().length === 0)
+          delete rooms[currentRoomCode];
+      }, 10_000);
+    }
   };
 
   const joinRoom = (roomCode: RoomCode) => {

--- a/backend/src/routes/rooms.ts
+++ b/backend/src/routes/rooms.ts
@@ -38,8 +38,7 @@ const registerRoomEvents = (io: IoType, socket: SocketType) => {
     if (ensemble.getMembers().length === 0) {
       setTimeout(() => {
         // If it is still empty, delete the room
-        if (ensemble.getMembers().length === 0)
-          delete rooms[currentRoomCode];
+        if (ensemble.getMembers().length === 0) delete rooms[currentRoomCode];
       }, 10_000);
     }
   };


### PR DESCRIPTION
When the last user leaves the room, we want to delete the room to save on memory. 

To prepare for the case where the last user refreshes the page and wants to rejoin the room, we will wait some time (10 seconds) before we delete the room. This gives people time to rejoin the room. 