### PR TITLE
fix(backend): send ensemble state on create room

### DIFF
--- a/backend/src/routes/rooms.ts
+++ b/backend/src/routes/rooms.ts
@@ -20,6 +20,7 @@ const registerRoomEvents = (io: IoType, socket: SocketType) => {
     socket.data.roomCode = roomCode;
     // Let everyone in the room know the list of users changed
     io.to(roomCode).emit("room:user-list", ensemble.getMembers());
+    io.to(roomCode).emit("ensemble:update", ensemble.toObject());
     callback(roomCode);
   };
 


### PR DESCRIPTION
Bad things happened when this was not the case. Duplicate barlines when you leave and create a new room. 

![image](https://github.com/JoshWannaPaas/eight-bar-line/assets/22456621/32443c8f-6a4c-4f31-8f6c-67fb81862e72)